### PR TITLE
Error in focus button icons focused

### DIFF
--- a/src/components/buttons/buttons.css
+++ b/src/components/buttons/buttons.css
@@ -178,6 +178,10 @@
     background: unset;
     margin: 0;
     padding: 0;
+
+    &:focus {
+      box-shadow: unset;
+    }
   }
 
   &.hggs-button--outline {


### PR DESCRIPTION
# Error in focus button icons focused

## Description
- [x] Set box shadow unset when focus an icon/icon labeled.

Close #98

## Screenhos

### Before
![Screenshot_20221030_194803](https://user-images.githubusercontent.com/1202463/198897395-f35e8bc9-99ab-4a02-990c-48828820ea7d.png)

### After
![Screenshot_20221030_201949](https://user-images.githubusercontent.com/1202463/198897446-00954fd1-2203-4fe2-aade-a9692d663712.png)
