### PR TITLE
#106 Create tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,10 +70,6 @@
           </li>
           <li class="hggs-list-item">
             <a href="./src/components/logo/logo.html">Logo</a>
-            <span
-              class="hggs-tag hggs-tag--small hggs-tag--secondary hggs-tag--rounded"
-              >new</span
-            >
           </li>
           <li class="hggs-list-item">
             <a href="./src/components/option/option.html">Option</a>
@@ -95,6 +91,13 @@
           </li>
           <li class="hggs-list-item">
             <a href="./src/components/text/text.html">Text</a>
+          </li>
+          <li class="hggs-list-item">
+            <a href="./src/components/tooltip/tooltip.html">Tooltip</a>
+            <span
+              class="hggs-tag hggs-tag--small hggs-tag--secondary hggs-tag--rounded"
+              >new</span
+            >
           </li>
         </ul>
       </main>

--- a/src/components/tooltip/tooltip.css
+++ b/src/components/tooltip/tooltip.css
@@ -1,0 +1,96 @@
+.hggs-tooltip {
+  position:relative;
+  display:inline-block;
+  color: var(--tooltip-color, var(--hggs-font-color-default));
+  font-family: var(--tooltip-font-famiy, var(--hggs-font-famiy-default));
+  font-size: var(--tooltip-font-size, var(--hggs-font-size-default));
+  font-weight: var(--tooltip-font-weight, var(--text-font-weight-default));
+  line-height: var(--tooltip-line-height, var(--hggs-line-height-default));
+  margin: var(--tooltip-margin, var(--hggs-space-default));
+
+  &:before {
+    content: "";
+    position: absolute;
+    top: -6px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: var(--tooltip-triangle-border-width, 4px 6px 0 6px);
+    border-style: var(--tooltip-triangle-border-style, solid);
+    border-color: var(--tooltip-triangle-border-color, var(--hggs-color-gray-004-default) transparent transparent transparent);
+    z-index: var(--tooltip-triangle-z-index, var(--hggs-layer-10-default));
+    opacity:0;
+  }
+
+  &:before,
+  &.hggs-tooltip--top:before{
+    left: 50%;
+  }
+
+  &.hggs-tooltip--left:before {
+    left: 0%;
+    top: 50%;
+    margin-left: var(--tooltip-triangle-left-margin-left, -12px);
+    transform:translatey(-50%) rotate(-90deg)
+  }
+
+  &.hggs-tooltip--down:before{
+    top: 100%;
+    margin-top: var(--tooltip-triangle-down-margin-top, 8px);
+    transform: translateX(-50%) translatey(-100%) rotate(-180deg)
+  }
+
+  &.hggs-tooltip--right:before{
+    left: 100%;
+    top: 50%;
+    margin-left: var(--tooltip-triangle-right-margin-left, 1px);
+    transform:translatey(-50%) rotate(90deg)
+  }
+
+  &:after {
+    width: var(--tooltip-box-width, 100%);
+    min-width: var(--tooltip-box-min-width, 80px);
+    content: attr(data-tooltip);
+    position: absolute;
+    left: 50%;
+    top: -6px;
+    transform: translateX(-50%) translateY(-100%);
+    background: var(--tooltip-box-background, var(--hggs-color-gray-004-default));
+    text-align: center;
+    padding: var(--tooltip-box-padding, var(--hggs-space-xs-default));
+    font-size: var(--tooltip-box-font-size, var(--hggs-font-size-default));
+    border-radius: var(--tooltip-box-border-radius, var(--hggs-border-size-lg-default));
+    pointer-events: none;
+    z-index: var(--tooltip-box-z-index, var(--hggs-layer-10-default));
+    opacity: 0;
+  }
+
+  &:after,
+  &.hggs-tooltip--top:after{
+    left: 50%;
+  }
+
+  &.hggs-tooltip--left:after{
+    left: 0%;
+    top: 50%;
+    margin-left: -8px;
+    transform: translateX(-100%) translateY(-50%);
+  }
+
+  &.hggs-tooltip--down:after{
+    top: 100%;
+    margin-top: 8px;
+    transform: translateX(-50%) translateY(0%);
+  }
+
+  &.hggs-tooltip--right:after{
+    left: 100%;
+    top: 50%;
+    margin-left: 8px;
+    transform: translateX(0%) translateY(-50%);
+  }
+
+  &:hover:after,
+  &:hover:before {
+    opacity: .9;
+  }
+}

--- a/src/components/tooltip/tooltip.css
+++ b/src/components/tooltip/tooltip.css
@@ -2,7 +2,7 @@
   position:relative;
   display:inline-block;
   color: var(--tooltip-color, var(--hggs-font-color-default));
-  font-family: var(--tooltip-font-famiy, var(--hggs-font-famiy-default));
+  font-family: var(--tooltip-font-family, var(--hggs-font-famiy-default));
   font-size: var(--tooltip-font-size, var(--hggs-font-size-default));
   font-weight: var(--tooltip-font-weight, var(--text-font-weight-default));
   line-height: var(--tooltip-line-height, var(--hggs-line-height-default));
@@ -11,14 +11,14 @@
   &:before {
     content: "";
     position: absolute;
-    top: -6px;
+    top: -7px;
     left: 50%;
     transform: translateX(-50%);
     border-width: var(--tooltip-triangle-border-width, 4px 6px 0 6px);
     border-style: var(--tooltip-triangle-border-style, solid);
     border-color: var(--tooltip-triangle-border-color, var(--hggs-color-gray-004-default) transparent transparent transparent);
     z-index: var(--tooltip-triangle-z-index, var(--hggs-layer-10-default));
-    opacity:0;
+    opacity: 0;
   }
 
   &:before,
@@ -58,6 +58,7 @@
     text-align: center;
     padding: var(--tooltip-box-padding, var(--hggs-space-xs-default));
     font-size: var(--tooltip-box-font-size, var(--hggs-font-size-default));
+    color: var(--tooltip-box-color, var(--hggs-font-color-default));
     border-radius: var(--tooltip-box-border-radius, var(--hggs-border-size-lg-default));
     pointer-events: none;
     z-index: var(--tooltip-box-z-index, var(--hggs-layer-10-default));
@@ -72,7 +73,7 @@
   &.hggs-tooltip--left:after{
     left: 0%;
     top: 50%;
-    margin-left: -8px;
+    margin-left: -7px;
     transform: translateX(-100%) translateY(-50%);
   }
 
@@ -85,12 +86,12 @@
   &.hggs-tooltip--right:after{
     left: 100%;
     top: 50%;
-    margin-left: 8px;
+    margin-left: 9px;
     transform: translateX(0%) translateY(-50%);
   }
 
   &:hover:after,
   &:hover:before {
-    opacity: .9;
+    opacity: var(--tooltip-opacity, .9);
   }
 }

--- a/src/components/tooltip/tooltip.html
+++ b/src/components/tooltip/tooltip.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>hggs-tooltip</title>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="../../../dist/higgsboson.css"
+    />
+
+    <script
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/underscore@1.13.1/underscore-umd-min.js"
+    ></script>
+
+    <script type="text/javascript" src="../../helpers/dom.js"></script>
+    <script type="text/javascript" src="../../helpers/styles.js"></script>
+    <script type="text/javascript" src="../../helpers/dom.js"></script>
+
+    <script type="text/javascript" src="./tooltip.metadata.js"></script>
+
+    <script id="template" type="text/template">
+      <h1 class="hggs-h1" style="margin-top: 0"><%= data.title %></h1>
+
+      <% _.each(data.default, function(d) { %>
+        <%
+          const articleStyle = getStyles(d?.styles?.article);
+          const headerStyle = getStyles(d?.styles?.header);
+          const tooltipStyles = getClasses(d?.styles?.tooltip);
+          const tooltipClass = getClasses(d?.classes?.tooltip);
+        %>
+
+        <article style="<%= articleStyle %>">
+          <h3 class="hggs-h3" style="<%= headerStyle %>">
+            <%= d.title %>
+          </h3>
+          <span class="<%= tooltipClass %>" style="<%= tooltipStyles %>" data-tooltip="I’m the tooltip text">
+            Hover me to see the tooltip
+          </span>
+        </article>
+      <% }); %>
+    </script>
+  </head>
+
+  <body>
+    <div
+      id="body"
+      class="hggs-app hggs-flex--column-top-left"
+      style="width: 100%; height: 100%; padding: 30px"
+    ></div>
+  </body>
+  <script type="text/javascript" src="../../helpers/render.js"></script>
+</html>

--- a/src/components/tooltip/tooltip.md
+++ b/src/components/tooltip/tooltip.md
@@ -1,0 +1,92 @@
+# Tooltip
+
+## Root component class name
+
+`hggs-tooltip`
+
+## Theme selector
+
+```css
+.hggs-tooltip {
+  /*
+  ... put here variables ...
+  */
+}
+```
+
+## Component variables
+
+```
+--tooltip-box-background
+--tooltip-box-border-radius
+--tooltip-box-font-size
+--tooltip-box-min-width
+--tooltip-box-padding
+--tooltip-box-width
+--tooltip-box-z-index
+--tooltip-color
+--tooltip-font-size
+--tooltip-font-weight
+--tooltip-line-height
+--tooltip-margin
+--tooltip-triangle-border-color
+--tooltip-triangle-border-style
+--tooltip-triangle-border-width
+--tooltip-triangle-down-margin-top
+--tooltip-triangle-left-margin-left
+--tooltip-triangle-right-margin-left
+--tooltip-triangle-z-index
+-tooltip-font-famiy
+```
+
+## HTML Structure
+
+### Default
+
+#### Basic HTML structure
+
+```html
+<span class="hggs-tooltip" data-tooltip="I am the text for the tooltip">
+  Hover me
+</span>
+```
+
+### Up
+
+#### Basic HTML structure with `up` modifier
+
+```html
+<span class="hggs-tooltip hggs-tooltip--up" data-tooltip="I am the text for the tooltip">
+  Hover me
+</span>
+```
+
+### Down
+
+#### Basic HTML structure with `down` modifier
+
+```html
+<span class="hggs-tooltip hggs-tooltip--down" data-tooltip="I am the text for the tooltip">
+  Hover me
+</span>
+```
+
+### Left
+
+#### Basic HTML structure with `left` modifier
+
+```html
+<span class="hggs-tooltip hggs-tooltip--left" data-tooltip="I am the text for the tooltip">
+  Hover me
+</span>
+```
+
+### Right
+
+#### Basic HTML structure with `right` modifier
+
+```html
+<span class="hggs-tooltip hggs-tooltip--right" data-tooltip="I am the text for the tooltip">
+  Hover me
+</span>
+```

--- a/src/components/tooltip/tooltip.md
+++ b/src/components/tooltip/tooltip.md
@@ -19,16 +19,19 @@
 ```
 --tooltip-box-background
 --tooltip-box-border-radius
+--tooltip-box-color
 --tooltip-box-font-size
 --tooltip-box-min-width
 --tooltip-box-padding
 --tooltip-box-width
 --tooltip-box-z-index
 --tooltip-color
+--tooltip-font-family
 --tooltip-font-size
 --tooltip-font-weight
 --tooltip-line-height
 --tooltip-margin
+--tooltip-opacity
 --tooltip-triangle-border-color
 --tooltip-triangle-border-style
 --tooltip-triangle-border-width
@@ -36,7 +39,6 @@
 --tooltip-triangle-left-margin-left
 --tooltip-triangle-right-margin-left
 --tooltip-triangle-z-index
--tooltip-font-famiy
 ```
 
 ## HTML Structure

--- a/src/components/tooltip/tooltip.metadata.js
+++ b/src/components/tooltip/tooltip.metadata.js
@@ -1,0 +1,49 @@
+const data = {
+  title: "Tooltip",
+  default: [
+    {
+      title: "tooltip --up",
+      styles: {
+        header: headerStyles,
+        article: [...articleStyles],
+        tooltip: ["margin-left: 0"],
+      },
+      classes: {
+        tooltip: ["hggs-tooltip", "hggs-tooltip--up"],
+      },
+    },
+    {
+      title: "tooltip --right",
+      styles: {
+        header: headerStyles,
+        article: [...articleStyles],
+        tooltip: ["margin-left: 0"],
+      },
+      classes: {
+        tooltip: ["hggs-tooltip", "hggs-tooltip--right"],
+      },
+    },
+    {
+      title: "tooltip --down",
+      styles: {
+        header: headerStyles,
+        article: [...articleStyles],
+        tooltip: ["margin-left: 0"],
+      },
+      classes: {
+        tooltip: ["hggs-tooltip", "hggs-tooltip--down"],
+      },
+    },
+    {
+      title: "tooltip --left",
+      styles: {
+        header: headerStyles,
+        article: [...articleStyles, "margin-bottom: 50px"],
+        tooltip: ["margin-left: 20%"],
+      },
+      classes: {
+        tooltip: ["hggs-tooltip", "hggs-tooltip--left"],
+      },
+    },
+  ],
+};

--- a/src/theme/captain-america/components/tooltip.css
+++ b/src/theme/captain-america/components/tooltip.css
@@ -1,0 +1,24 @@
+.hggs-tooltip {
+  --tooltip-box-background: var(--hggs-color-gray-007);
+  --tooltip-box-border-radius: var(--hggs-border-radius);
+  --tooltip-box-color: var(--hggs-font-color-light);
+  --tooltip-box-font-size: var(--hggs-font-size);
+  --tooltip-box-min-width: 100px;
+  --tooltip-box-padding: var(--hggs-space-horizontal-xs);
+  --tooltip-box-width: 100%;
+  --tooltip-box-z-index: var(--hggs-layer-10);
+  --tooltip-color: var(--hggs-font-color);
+  --tooltip-font-family: var(--hggs-font-size);
+  --tooltip-font-size: var(--hggs-font-size);
+  --tooltip-font-weight: var(--hggs-font-weight);
+  --tooltip-line-height: var(--hggs-line-height);
+  --tooltip-margin: var(--hggs-space-horizontal);
+  --tooltip-opacity: .9;
+  --tooltip-triangle-border-color: var(--hggs-color-gray-007) transparent transparent transparent;
+  --tooltip-triangle-border-style: solid;
+  --tooltip-triangle-border-width: 4px 6px 0 6px;
+  --tooltip-triangle-down-margin-top: 8px;
+  --tooltip-triangle-left-margin-left: -12px;
+  --tooltip-triangle-right-margin-left: 1px;
+  --tooltip-triangle-z-index: var(--hggs-layer-10);
+}

--- a/src/theme/captain-america/index.css
+++ b/src/theme/captain-america/index.css
@@ -30,3 +30,4 @@
 @import "./components/tag.css";
 @import "./components/box.css";
 @import "./components/dialog.css";
+@import "./components/tooltip.css";

--- a/src/theme/captain-america/vars.css
+++ b/src/theme/captain-america/vars.css
@@ -177,6 +177,7 @@
 
   /* Font colors */
   --hggs-font-color: var(--hggs-color-gray-005);
+  --hggs-font-color-light: var(--hggs-color-gray-001);
 
   /* Font sizes */
   --hggs-font-size-5xl: 1.9rem;
@@ -357,6 +358,7 @@
 
     /* FONT */
     --hggs-font-color: var(--hggs-color-gray-008);
+    --hggs-font-color-light: var(--hggs-color-gray-002);
 
     /* FILTERS */
     --hggs-filter-gray: brightness(0) saturate(100%) invert(100%) sepia(0%)

--- a/src/theme/caramel/components/tooltip.css
+++ b/src/theme/caramel/components/tooltip.css
@@ -1,0 +1,24 @@
+.hggs-tooltip {
+  --tooltip-box-background: var(--hggs-color-background-senary);
+  --tooltip-box-border-radius: var(--hggs-border-radius-sm);
+  --tooltip-box-color: var(--hggs-font-color-gray);
+  --tooltip-box-font-size: var(--hggs-font-size-sm);
+  --tooltip-box-min-width: 100px;
+  --tooltip-box-padding: var(--hggs-space-horizontal-xs);
+  --tooltip-box-width: 80%;
+  --tooltip-box-z-index: var(--hggs-layer-10);
+  --tooltip-color: var(--hggs-font-color);
+  --tooltip-font-family: var(--hggs-font-size);
+  --tooltip-font-size: var(--hggs-font-size);
+  --tooltip-font-weight: var(--hggs-font-weight);
+  --tooltip-line-height: var(--hggs-line-height);
+  --tooltip-margin: var(--hggs-space);
+  --tooltip-opacity: .9;
+  --tooltip-triangle-border-color: var(--hggs-color-background-senary) transparent transparent transparent;
+  --tooltip-triangle-border-style: solid;
+  --tooltip-triangle-border-width: 4px 6px 0 6px;
+  --tooltip-triangle-down-margin-top: 8px;
+  --tooltip-triangle-left-margin-left: -12px;
+  --tooltip-triangle-right-margin-left: 1px;
+  --tooltip-triangle-z-index: var(--hggs-layer-10);
+}

--- a/src/theme/caramel/index.css
+++ b/src/theme/caramel/index.css
@@ -30,3 +30,4 @@
 @import "./components/tag.css";
 @import "./components/box.css";
 @import "./components/dialog.css";
+@import "./components/tooltip.css";

--- a/src/theme/caramel/vars.css
+++ b/src/theme/caramel/vars.css
@@ -268,6 +268,7 @@
 
   /* Font colors */
   --hggs-font-color: var(--hggs-color);
+  --hggs-font-color-gray: var(--hggs-color-gray);
 
   /* Font sizes */
   --hggs-font-size-2xs: calc(var(--hggs-font-size-sm) / 1.6);

--- a/src/theme/default.css
+++ b/src/theme/default.css
@@ -108,7 +108,6 @@
   --hggs-border-radius-md-default: 0px;
   --hggs-border-radius-default: 0px;
   --hggs-border-size-default: 1px;
-  --hggs-border-size-lg-default: 2px;
   --hggs-border-size-lg-default: 3px;
   --hggs-border-size-xl-default: 8px;
   --hggs-border-type-default: solid;
@@ -171,6 +170,7 @@
   --hggs-space-2xs-default: calc(var(--hggs-space-default) / 6);
 
   /* LAYERS */
+  --hggs-layer-20-default: 20;
   --hggs-layer-10-default: 11;
   --hggs-layer-0-default: 1;
 

--- a/src/theme/index.css
+++ b/src/theme/index.css
@@ -4,7 +4,7 @@
 
 /* THEME */
 /*@import "./captain-america/index.css";*/
-@import "./caramel/index.css";
+/*@import "./caramel/index.css";*/
 
 /* COMPONENTS */
 @import "../components/flex/flex.css";
@@ -30,3 +30,4 @@
 @import "../components/dialog/dialog.css";
 @import "../components/table/table.css";
 @import "../components/box/box.css";
+@import "../components/tooltip/tooltip.css";


### PR DESCRIPTION
# Create tooltip
Close #106 

## Summary of changes
- [x] Create tooltip component
- [x] Add tooltip metadata and html template
- [x] Set tooltip on `caramel` and `captain-america` themes 

## Screenshots

### Default dark mode
<img width="631" alt="Captura de pantalla 2022-11-21 a las 16 46 11" src="https://user-images.githubusercontent.com/1202463/203099037-3ab2b0f1-0648-472b-beda-49ecffb1b5f1.png">

### Default light mode
<img width="631" alt="Captura de pantalla 2022-11-21 a las 16 46 19" src="https://user-images.githubusercontent.com/1202463/203099039-d73afb5f-2a08-4881-a163-287b95720002.png">

### Caramel light mode 
<img width="629" alt="Captura de pantalla 2022-11-21 a las 16 46 39" src="https://user-images.githubusercontent.com/1202463/203099041-96b2eed6-94e2-4da9-b130-5edb75bed777.png">

### Caramel dark mode 
<img width="629" alt="Captura de pantalla 2022-11-21 a las 16 46 52" src="https://user-images.githubusercontent.com/1202463/203099043-54a95f2a-3d59-469b-a922-b38d469d85ff.png">

### Captain America light mode 
<img width="631" alt="Captura de pantalla 2022-11-21 a las 16 45 44" src="https://user-images.githubusercontent.com/1202463/203099028-8c91bc2b-a3e2-43ef-9125-4f0eb319e560.png">

### Captain America dark mode 
<img width="631" alt="Captura de pantalla 2022-11-21 a las 16 45 54" src="https://user-images.githubusercontent.com/1202463/203099033-dad954a0-1f93-45f2-a3ec-a3ad08743148.png">

