### PR TITLE
138 add accent color as theme property

### DIFF
--- a/src/components/app/app.css
+++ b/src/components/app/app.css
@@ -9,7 +9,7 @@
   background: var(--app-background, var(--hggs-color-background-default));
   color: var(--app-color, var(--hggs-color-default));
   padding: var(--app-padding, var(--hggs-space-md-default) var(--hggs-space-default));
-  font-size: var(--app-font-size, 1.5rem);
+  font-size: var(--app-font-size, var(--hggs-font-size-default));
   font-family: var(--hggs-font-family, var(--hggs-font-family-default));
 
   &.hggs-app--left {

--- a/src/components/checkbox/checkbox.css
+++ b/src/components/checkbox/checkbox.css
@@ -13,6 +13,7 @@
   justify-content: flex-start;
   width: 100%;
   position: relative;
+  accent-color: var(--checkbox-accent-color, var(--hggs-accent-color-default));
 
   & input[type="checkbox"] {
     appearance: none;

--- a/src/components/checkbox/checkbox.md
+++ b/src/components/checkbox/checkbox.md
@@ -19,11 +19,7 @@
 ## Component variables
 
 ```
---checkbox-label-color
---checkbox-label-font-family
---checkbox-label-font-size
---checkbox-label-font-style
---checkbox-label-font-weight
+--checkbox-accent-color
 --checkbox-background
 --checkbox-border
 --checkbox-border-radius
@@ -39,6 +35,11 @@
 --checkbox-ckeck-icon-transform-before
 --checkbox-ckeck-icon-width-after
 --checkbox-ckeck-icon-width-before
+--checkbox-label-color
+--checkbox-label-font-family
+--checkbox-label-font-size
+--checkbox-label-font-style
+--checkbox-label-font-weight
 --checkbox-margin-left
 --checkbox-outline-focus
 --checkbox-size

--- a/src/components/radio/radio.css
+++ b/src/components/radio/radio.css
@@ -16,6 +16,7 @@
   position: relative;
 
   & input[type="radio"] {
+    accent-color: var(--radio-accent-color, var(--hggs-accent-color-default));
     position: absolute;
     width: var(--radio-size, var(--hggs-space-default));
     height: var(--radio-size, var(--hggs-space-default));

--- a/src/components/radio/radio.md
+++ b/src/components/radio/radio.md
@@ -19,6 +19,7 @@
 ## Component variables
 
 ```
+--radio-accent-color
 --radio-border
 --radio-border-checked
 --radio-inside-background-color
@@ -29,7 +30,7 @@
 --radio-inside-box-shadow-focus
 --radio-inside-outline-focus
 --radio-inside-transition
---radio-label-color
+--radio-label-color 
 --radio-label-font-family
 --radio-label-font-size
 --radio-label-font-style

--- a/src/theme/default.css
+++ b/src/theme/default.css
@@ -42,6 +42,9 @@
   --hggs-color-senary-default: var(--hggs-color-gray-011-default);
   --hggs-color-senary-hover-default: var(--hggs-color-tertiary-default);
 
+  /* Accent colors */
+  --hggs-accent-color-default: var(--hggs-color-primary-default);
+
   /* Filters colors */
   --hggs-filter-gray-008-default:
     brightness(0) saturate(100%) invert(8%) sepia(18%) saturate(1214%) hue-rotate(194deg)


### PR DESCRIPTION
# Add accent color as theme property

## Description

I decide add this property to set the accent color in some components to reduce some noise and overwriting rules.
https://github.com/javierlopezdeancos/higgsboson/discussions/73

### Components to set accent color
https://css-tricks.com/almanac/properties/a/accent-color

It works with specific form controls
- [x] checkboxes (`<input type="checkbox">`)
- [x] radio buttons (`<input type="radio">`)
- [ ] range (`<input type="range">`)
- [ ] progress (`<progress>`)

### Summary of changes
- [x] Add color accent token in default theme
- [x] Add color accent property in checkboxes
- [x] Add color accent property in radios
- [x] replace rem value by correct default theme font size in app 

Close #138 