### PR TITLE
Set default theme typography fluid

### DIFF
--- a/src/components/app/app.css
+++ b/src/components/app/app.css
@@ -9,7 +9,7 @@
   background: var(--app-background, var(--hggs-color-background-default));
   color: var(--app-color, var(--hggs-color-default));
   padding: var(--app-padding, var(--hggs-space-md-default) var(--hggs-space-default));
-  font-size: var(--app-font-size, var(--hggs-font-size-default));
+  font-size: var(--app-font-size, var(---hggs-font-size-root-default));
   font-family: var(--hggs-font-family, var(--hggs-font-family-default));
 
   &.hggs-app--left {

--- a/src/components/inputs/inputs.css
+++ b/src/components/inputs/inputs.css
@@ -5,7 +5,7 @@
   border-radius: var(--input-border-radius, var(--hggs-border-radius-default));
   padding: var(--input-padding, var(--hggs-space-sm-default) var(--hggs-space-sm-default));
   font-family: var(--input-font-family, var(--hggs-font-family-default));
-  font-size: var(--input-font-size, var(--hggs-font-size-lg-default));
+  font-size: var(--input-font-size, var(--hggs-font-size-default));
   color: var(--input-color, var(--hggs-color-default));
   box-sizing: border-box;
   background: transparent;
@@ -19,7 +19,7 @@
   &.hggs-input--small {
     height: var(--input-height-small, var(--hggs-space-default));
     padding: var(--input-padding-small, var(--hggs-space-2xs-default) var(--hggs-space-sm-default));
-    font-size: var(--input-font-size-small, var(--hggs-font-size-default));
+    font-size: var(--input-font-size-small, var(--hggs-font-size-2xs-default));
   }
 
   &::placeholder {

--- a/src/components/titles/titles.css
+++ b/src/components/titles/titles.css
@@ -36,21 +36,21 @@
 
 .hggs-h4 {
   font-family: var(--title-h4-font-family, var(--hggs-font-family-default));
-  font-size: var(--title-h4-font-size, calc(var(--hggs-font-size-3xl-default) - 2px));
+  font-size: var(--title-h4-font-size, var(--hggs-font-size-2xl-default));
   font-weight: var(--title-h4-font-weight, var(--hggs-font-weight-lg-default));
   margin: var(--title-h4-margin, calc(var(--hggs-space-default) / 2) 0 calc(var(--hggs-space-default) / 2) 0);
 }
 
 .hggs-h5 {
   font-family: var(--title-h5-font-family, var(--hggs-font-family-default));
-  font-size: var(--title-h5-font-size, var(--hggs-font-size-2xl-default));
+  font-size: var(--title-h5-font-size, var(--hggs-font-size-xl-default));
   font-weight: var(--title-h5-font-weight, var(--hggs-font-weight-lg-default));
   margin: var(--title-h5-margin, calc(var(--hggs-space-default) / 2) 0 calc(var(--hggs-space-default) / 2) 0);
 }
 
 .hggs-h6 {
   font-family: var(--title-h6-font-family, var(--hggs-font-family-default));
-  font-size: var(--title-h6-font-size, calc(var(--hggs-font-size-2xl-default) - 2px));
+  font-size: var(--title-h6-font-size, var(--hggs-font-size-lg-default));
   font-weight: var(--title-h6-font-weight, var(--hggs-font-weight-lg-default));
   margin: var(--title-h6-margin, var(--hggs-space-sm-default) 0 var(--hggs-space-sm-default) 0);
 }

--- a/src/theme/default.css
+++ b/src/theme/default.css
@@ -92,17 +92,18 @@
   --hggs-font-color-002-default: var(--hggs-color-gray-010-default);
 
   /* Font sizes */
-  --hggs-font-size-5xl-default: 38px;
-  --hggs-font-size-4xl-default: 32px;
-  --hggs-font-size-3xl-default: 28px;
-  --hggs-font-size-2xl-default: 24px;
-  --hggs-font-size-xl-default: 22px;
-  --hggs-font-size-lg-default: 20px;
-  --hggs-font-size-md-default: 18px;
-  --hggs-font-size-default: 16px;
-  --hggs-font-size-sm-default: 14px;
-  --hggs-font-size-xs-default: 12px;
-  --hggs-font-size-2xs-default: 10px;
+  --hggs-font-size-root-default: clamp(2.89rem, calc(2.77rem + 0.56vw), 3.21rem);
+  --hggs-font-size-5xl-default: clamp(2.57rem, calc(2.47rem + 0.50vw), 2.85rem);
+  --hggs-font-size-4xl-default: clamp(2.28rem, calc(2.19rem + 0.44vw), 2.53rem);
+  --hggs-font-size-3xl-default: clamp(2.03rem, calc(1.95rem + 0.39vw), 2.25rem);
+  --hggs-font-size-2xl-default: clamp(1.80rem, calc(1.73rem + 0.35vw), 2.00rem);
+  --hggs-font-size-xl-default: clamp(1.60rem, calc(1.54rem + 0.31vw), 1.78rem);
+  --hggs-font-size-lg-default:  clamp(1.42rem, calc(1.37rem + 0.27vw), 1.58rem);
+  --hggs-font-size-md-default: clamp(1.27rem, calc(1.22rem + 0.24vw), 1.41rem);
+  --hggs-font-size-default: clamp(1.13rem, calc(1.08rem + 0.22vw), 1.25rem);
+  --hggs-font-size-sm-default: clamp(1.00rem, calc(0.96rem + 0.19vw), 1.11rem);
+  --hggs-font-size-xs-default: clamp(0.89rem, calc(0.85rem + 0.17vw), 0.99rem);
+  --hggs-font-size-2xs-default: clamp(0.79rem, calc(0.76rem + 0.15vw), 0.88rem);
 
   /* Font weights */
   --hggs-font-weight-default: 400;
@@ -115,9 +116,9 @@
   --hggs-font-letter-spacing-sm-default: 0.6px;
 
   /* Font line heights */
-  --hggs-line-height-default: 20px;
-  --hggs-line-height-sm-default: 15px;
-  --hggs-line-height-xs-default: 10px;
+  --hggs-line-height-default: 28px;
+  --hggs-line-height-sm-default: 25px;
+  --hggs-line-height-xs-default: 22px;
 
   /* BORDERS */
   --hggs-border-radius-md-default: 0;


### PR DESCRIPTION
# Set default theme typography fluid

## Issue
Close #141 

## Discusion
#87 

## Description

Take reference at this app to calc clamp functions
https://modern-fluid-typography.vercel.app/ or https://utopia.fyi/type/calculator

## Summary of changes
- [x] Set clamp functions values to new font sizes in default theme calc with https://utopia.fyi/type/calculator/
- [x] Adapt some font sizes in some components taking into account new fluid font size values 