### PR TITLE
Add transitions using transitions api

### DIFF
--- a/src/components/app/app.css
+++ b/src/components/app/app.css
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-type-no-unknown */
+
 .hggs-app {
   display: flex;
   flex-direction: column;
@@ -14,6 +16,10 @@
 
   &.hggs-app--left {
     align-items: flex-start;
+  }
+
+  &.hggs-app--transition {
+    view-transition-name: app;
   }
 
   /* TODO: Extract all of this into a container component */
@@ -39,5 +45,27 @@
     align-items: center;
     justify-content: flex-start;
     width: 100%;
+  }
+}
+
+/* stylelint-disable-next-line selector-pseudo-element-no-unknown */
+::view-transition-old(app) {
+  animation: fade 0.2s linear forwards;
+}
+
+/* stylelint-disable-next-line selector-pseudo-element-no-unknown */
+::view-transition-new(app) {
+  animation: fade 0.3s linear reverse;
+}
+
+@keyframes fade {
+  0% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(50px);
   }
 }

--- a/src/components/buttons/buttons.css
+++ b/src/components/buttons/buttons.css
@@ -5,7 +5,7 @@
   margin:
     var(--button-margin-vertical, var(--hggs-space-default))
     var(--button-margin-horizontal, var(--hggs-space-xs-default));
-  font-size: var(--button-font-size-medium, var(--hggs-font-size-lg-default));
+  font-size: var(--button-font-size-medium, var(--hggs-font-size-default));
   font-family: var(--button-font-family, var(--hggs-font-family));
   font-weight: var(--button-font-weight, var(--hggs-font-weight-default));
   color: var(--button-color, var(--hggs-color-quinary-default));
@@ -308,11 +308,11 @@
 
   &.hggs-button--medium {
     padding: var(--button-padding-medium, calc(var(--hggs-space-default) / 1.3) var(--hggs-space-md-default));
-    font-size: var(--button-font-size-medium, var(--hggs-font-size-xl-default));
+    font-size: var(--button-font-size-medium, var(--hggs-font-size-lg-default));
   }
 
   &.hggs-button--small:not(.hggs-button--circle, .hggs-button--square) {
     padding: var(--button-padding-small, var(--hggs-space-xs-default) var(--hggs-space-sm-default));
-    font-size: var(--button-font-size-small, var(--hggs-font-size-sm-default));
+    font-size: var(--button-font-size-small, var(--hggs-font-size-xs-default));
   }
 }

--- a/src/components/checkbox/checkbox.css
+++ b/src/components/checkbox/checkbox.css
@@ -13,7 +13,7 @@
   justify-content: flex-start;
   width: 100%;
   position: relative;
-  accent-color: var(--checkbox-accent-color, var(--hggs-accent-color-default));
+  accent-color: var(--checkbox-accent-color, var(--hggs-color-accent-default));
 
   & input[type="checkbox"] {
     appearance: none;

--- a/src/components/radio/radio.css
+++ b/src/components/radio/radio.css
@@ -16,7 +16,7 @@
   position: relative;
 
   & input[type="radio"] {
-    accent-color: var(--radio-accent-color, var(--hggs-accent-color-default));
+    accent-color: var(--radio-accent-color, var(--hggs-color-accent-default));
     position: absolute;
     width: var(--radio-size, var(--hggs-space-default));
     height: var(--radio-size, var(--hggs-space-default));

--- a/src/theme/default.css
+++ b/src/theme/default.css
@@ -42,9 +42,6 @@
   --hggs-color-senary-default: var(--hggs-color-gray-011-default);
   --hggs-color-senary-hover-default: var(--hggs-color-tertiary-default);
 
-  /* Accent colors */
-  --hggs-accent-color-default: var(--hggs-color-primary-default);
-
   /* Filters colors */
   --hggs-filter-gray-008-default:
     brightness(0) saturate(100%) invert(8%) sepia(18%) saturate(1214%) hue-rotate(194deg)
@@ -71,6 +68,7 @@
 
   /* General colors */
   --hggs-color-default: var(--hggs-color-quaternary-default);
+  --hggs-color-accent-default: var(--hggs-color-primary-default);
   --hggs-color-error-default: #8c565a;
   --hggs-color-success-default: #6c7c6c;
   --hggs-color-disabled-default: var(--hggs-color-gray-004-default);


### PR DESCRIPTION
# Add transitions using transition API

## Issue
Close #135 

## Description
Set app container with transition API 

API reference https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API

![image](https://github.com/javierlopezdeancos/higgsboson/assets/1202463/8b35799a-4fcf-4910-b18b-a73912c19864)

## Summary of changes
- [x] Add transition modifier to app container with transition API
- [x] Rename color accent default theme variable 

## Screenshots 
![transition_api](https://github.com/javierlopezdeancos/higgsboson/assets/1202463/44257c96-c911-4b05-b928-c03f5c6f016e)
