### PR TITLE
Add `hggs-avatars` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ All available core components defined from their selectors, properties and value
 
 #### Components docs
   - [Avatar](/src/components/avatar/avatar.md)
+  - [Avatars](/src/components/avatar/avatars.md)
   - [Box](/src/components/box/box.md)
   - [Button](/src/components/buttons/buttons.md)
   - [Checkbox](/src/components/checkbox/checkbox.md)

--- a/index.html
+++ b/index.html
@@ -25,6 +25,10 @@
             <span class="hggs-tag hggs-tag--small hggs-tag--secondary hggs-tag--rounded">new</span>
           </li>
           <li class="hggs-list-item">
+            <a href="./src/components/avatars/avatars.html">Avatars</a>
+            <span class="hggs-tag hggs-tag--small hggs-tag--secondary hggs-tag--rounded">new</span>
+          </li>
+          <li class="hggs-list-item">
             <a href="./src/components/box/box.html">Box</a>
           </li>
           <li class="hggs-list-item">
@@ -105,7 +109,6 @@
           </li>
           <li class="hggs-list-item">
             <a href="./src/components/text/texts.html">Texts</a>
-            <span class="hggs-tag hggs-tag--small hggs-tag--secondary hggs-tag--rounded">new</span>
           </li>
           <li class="hggs-list-item">
             <a href="./src/components/tooltip/tooltip.html">Tooltip</a>

--- a/src/components/avatars/avatars.css
+++ b/src/components/avatars/avatars.css
@@ -1,0 +1,17 @@
+.hggs-avatars {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: var(--avatars-gap, var(--hggs-space-default));
+  width: 100%;
+  padding: 0;
+  margin: 0;
+
+  & .hggs-avatars-item {
+    display: block;
+  }
+
+  & .hggs-avatar {
+    margin: 0;
+  }
+}

--- a/src/components/avatars/avatars.html
+++ b/src/components/avatars/avatars.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>hggs-avatars</title>
+    <link rel="stylesheet" type="text/css" href="../../../dist/higgsboson.css" />
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/underscore@1.13.1/underscore-umd-min.js"></script>
+    <script type="text/javascript" src="../../helpers/dom.js"></script>
+    <script type="text/javascript" src="../../helpers/styles.js"></script>
+    <script type="text/javascript" src="./avatars.metadata.js"></script>
+    <script id="template" type="text/template">
+      <h1 class="hggs-h1" style="margin-top: 0"><%= data.title %></h1>
+
+      <!-- default box -->
+
+      <% _.each(data.default, function(avs) { %>
+        <%
+          const articleStyles = getStyles(avs?.styles?.article);
+          const headerStyles = getStyles(avs?.styles?.header);
+          const listTitle = avs?.titles?.list;
+          const listTitleStyles = getStyles(avs?.styles?.titles?.list);
+          const listClass = getClasses(avs?.classes?.list);
+          const itemTitle = avs?.titles?.item;
+          const itemTitleStyles = getStyles(avs?.styles?.titles?.item);
+          const itemClass = getClasses(avs?.classes?.item);
+          const figureTitle = avs?.titles?.figure;
+          const figureTitleStyles = getStyles(avs?.styles?.titles?.figure);
+          const figureClass = getClasses(avs?.classes?.figure);
+          const imageTitle = avs?.titles?.image;
+          const imageTitleStyles = getStyles(avs?.styles?.titles?.image);
+          const imageClass = getClasses(avs?.classes?.image);
+          const imageSrc = avs?.attributes?.image?.src;
+          const imageAlt = avs?.attributes?.image?.alt;
+        %>
+
+        <article style="<%= articleStyles %>">
+          <header style="<%= headerStyles %>">
+            <h3 class="hggs-h3" style="<%= listTitleStyles %>">
+              <%= listTitle %>
+            </h3>
+            <h4 class="hggs-h4" style="<%= itemTitleStyles %>">
+              <%= itemTitle %>
+            </h4>
+            <h5 class="hggs-h5" style="<%= figureTitleStyles %>">
+              <%= figureTitle %>
+            </h5>
+            <h6 class="hggs-h6" style="<%= imageTitleStyles %>">
+              <%= imageTitle %>
+            </h6>
+          </header>
+
+          <ul class="<%= listClass %>">
+            <% _.each(avs?.attributes, function(atbs) { %>
+              <%
+                const imageSrc = atbs?.image?.src;
+                const imageAlt = atbs?.image?.alt;
+              %>
+
+              <li class="<%= itemClass %>"r>
+                <figure class="<%= figureClass %>">
+                  <img class="<%= imageClass %>" src="<%= imageSrc %>" alt="<%= imageAlt %>" />
+                </figure>
+              </li>
+            <% }); %>
+          </ul>
+        </article>
+      <% }); %>
+
+      <!-- sizes box -->
+
+      <% _.each(data.sizes, function(avs) { %>
+        <%
+          const articleStyles = getStyles(avs?.styles?.article);
+          const headerStyles = getStyles(avs?.styles?.header);
+          const listTitle = avs?.titles?.list;
+          const listTitleStyles = getStyles(avs?.styles?.titles?.list);
+          const listClass = getClasses(avs?.classes?.list);
+          const itemTitle = avs?.titles?.item;
+          const itemTitleStyles = getStyles(avs?.styles?.titles?.item);
+          const itemClass = getClasses(avs?.classes?.item);
+          const figureTitle = avs?.titles?.figure;
+          const figureTitleStyles = getStyles(avs?.styles?.titles?.figure);
+          const figureClass = getClasses(avs?.classes?.figure);
+          const imageTitle = avs?.titles?.image;
+          const imageTitleStyles = getStyles(avs?.styles?.titles?.image);
+          const imageClass = getClasses(avs?.classes?.image);
+          const imageSrc = avs?.attributes?.image?.src;
+          const imageAlt = avs?.attributes?.image?.alt;
+        %>
+
+        <article style="<%= articleStyles %>">
+          <header style="<%= headerStyles %>">
+            <h3 class="hggs-h3" style="<%= listTitleStyles %>">
+              <%= listTitle %>
+            </h3>
+            <h4 class="hggs-h4" style="<%= itemTitleStyles %>">
+              <%= itemTitle %>
+            </h4>
+            <h5 class="hggs-h5" style="<%= figureTitleStyles %>">
+              <%= figureTitle %>
+            </h5>
+            <h6 class="hggs-h6" style="<%= imageTitleStyles %>">
+              <%= imageTitle %>
+            </h6>
+          </header>
+
+          <ul class="<%= listClass %>">
+            <% _.each(avs?.attributes, function(atbs) { %>
+              <%
+                const imageSrc = atbs?.image?.src;
+                const imageAlt = atbs?.image?.alt;
+              %>
+
+              <li class="<%= itemClass %>"r>
+                <figure class="<%= figureClass %>">
+                  <img class="<%= imageClass %>" src="<%= imageSrc %>" alt="<%= imageAlt %>" />
+                </figure>
+              </li>
+            <% }); %>
+          </ul>
+        </article>
+      <% }); %>
+    </script>
+  </head>
+
+  <body>
+    <div id="body" class="hggs-app hggs-app--left" style="width: 100%; height: 100%; padding: 30px"></div>
+  </body>
+  <script type="text/javascript" src="../../helpers/render.js"></script>
+</html>
+

--- a/src/components/avatars/avatars.md
+++ b/src/components/avatars/avatars.md
@@ -1,0 +1,111 @@
+[Home ](../../../README.md) >
+[ Componentes ](../../../README.md#components)
+
+# Avatars
+
+- [Avatars](#avatars)
+  - [Root component class name](#root-component-class-name)
+  - [Theme selector](#theme-selector)
+  - [Component variables](#component-variables)
+  - [HTML Structure](#html-structure)
+    - [Default](#default)
+      - [Basic HTML structure](#basic-html-structure)
+    - [Sizes](#sizes)
+      - [Avatar Big](#avatar-big)
+      - [Avatar Small](#avatar-small)
+
+## Root component class name
+
+`hggs-avatars`
+
+## Theme selector
+
+```css
+.hggs-avatars {
+  /*
+  ... put here variables ...
+  */
+}
+```
+
+## Component variables
+
+```
+--avatar-image-border-radius
+--avatar-image-size
+--avatar-image-size-big
+--avatar-image-size-small
+```
+
+## HTML Structure
+
+### Default
+
+#### Basic HTML structure
+
+```html
+<ul class="hggs-avatars">
+  <li class="hggs-avatars-item" r="">
+    <figure class="hggs-avatar">
+      <img class="hggs-avatar-image" src="https://javierlopezdeancos.dev/src/images/me.png" alt="higgsboson avatar example">
+    </figure>
+  </li>
+  <li class="hggs-avatars-item" r="">
+    <figure class="hggs-avatar">
+      <img class="hggs-avatar-image" src="https://avatars.githubusercontent.com/u/951580?v=4" alt="higgsboson avatar example">
+    </figure>
+  </li>
+  <li class="hggs-avatars-item" r="">
+    <figure class="hggs-avatar">
+      <img class="hggs-avatar-image" src="https://avatars.githubusercontent.com/u/539546?v=4" alt="higgsboson avatar example">
+    </figure>
+  </li>
+
+</ul>
+```
+
+### Sizes
+
+#### Avatar Big
+
+```html
+<ul class="hggs-avatars">
+  <li class="hggs-avatars-item" r="">
+    <figure class="hggs-avatar hggs-avatar--big">
+      <img class="hggs-avatar-image" src="https://javierlopezdeancos.dev/src/images/me.png" alt="higgsboson avatar example">
+    </figure>
+  </li>
+  <li class="hggs-avatars-item" r="">
+    <figure class="hggs-avatar hggs-avatar--big">
+      <img class="hggs-avatar-image" src="https://avatars.githubusercontent.com/u/951580?v=4" alt="higgsboson avatar example">
+    </figure>
+  </li>
+  <li class="hggs-avatars-item" r="">
+    <figure class="hggs-avatar hggs-avatar--big">
+      <img class="hggs-avatar-image" src="https://avatars.githubusercontent.com/u/539546?v=4" alt="higgsboson avatar example">
+    </figure>
+  </li>
+</ul>
+```
+
+#### Avatar Small
+
+```html
+<ul class="hggs-avatars">
+  <li class="hggs-avatars-item" r="">
+    <figure class="hggs-avatar hggs-avatar--small">
+      <img class="hggs-avatar-image" src="https://javierlopezdeancos.dev/src/images/me.png" alt="higgsboson avatar example">
+    </figure>
+  </li>
+  <li class="hggs-avatars-item" r="">
+    <figure class="hggs-avatar hggs-avatar--small">
+      <img class="hggs-avatar-image" src="https://avatars.githubusercontent.com/u/951580?v=4" alt="higgsboson avatar example">
+    </figure>
+  </li>
+  <li class="hggs-avatars-item" r="">
+    <figure class="hggs-avatar hggs-avatar--small">
+      <img class="hggs-avatar-image" src="https://avatars.githubusercontent.com/u/539546?v=4" alt="higgsboson avatar example">
+    </figure>
+  </li>
+</ul>
+```

--- a/src/components/avatars/avatars.metadata.js
+++ b/src/components/avatars/avatars.metadata.js
@@ -1,0 +1,183 @@
+const data = {
+  title: "Avatars",
+  default: [
+    {
+      titles: {
+        list: "hggs-avatars",
+        item: "hggs-avatars-item",
+        figure: "hggs-avatar",
+        image: "hggs-image",
+      },
+      styles: {
+        header: headerStyles,
+        article: articleStyles,
+        titles: {
+          list: titleStyles,
+          item: titleIndentation1xStyles,
+          figure: titleIndentation2xStyles,
+          image: titleIndentation3xStyles,
+        },
+      },
+      classes: {
+        list: ["hggs-avatars"],
+        item: ["hggs-avatars-item"],
+        figure: ["hggs-avatar"],
+        image: ["hggs-avatar-image"],
+      },
+      attributes: [
+        {
+          image: {
+            src: "https://javierlopezdeancos.dev/src/images/me.png",
+            alt: "higgsboson avatar example",
+          },
+        },
+        {
+          image: {
+            src: "https://avatars.githubusercontent.com/u/951580?v=4",
+            alt: "higgsboson avatar example",
+          },
+        },
+        {
+          image: {
+            src: "https://avatars.githubusercontent.com/u/539546?v=4",
+            alt: "higgsboson avatar example",
+          },
+        },
+      ],
+    },
+  ],
+  sizes: [
+    {
+      titles: {
+        list: "hggs-avatars",
+        item: "hggs-avatars-item",
+        figure: "hggs-avatar hggs-avatar--big",
+        image: "hggs-image",
+      },
+      styles: {
+        header: headerStyles,
+        article: articleStyles,
+        titles: {
+          list: titleStyles,
+          item: titleIndentation1xStyles,
+          figure: titleIndentation2xStyles,
+          image: titleIndentation3xStyles,
+        },
+      },
+      classes: {
+        list: ["hggs-avatars"],
+        item: ["hggs-avatars-item"],
+        figure: ["hggs-avatar hggs-avatar--big"],
+        image: ["hggs-avatar-image"],
+      },
+      attributes: [
+        {
+          image: {
+            src: "https://javierlopezdeancos.dev/src/images/me.png",
+            alt: "higgsboson avatar example",
+          },
+        },
+        {
+          image: {
+            src: "https://avatars.githubusercontent.com/u/951580?v=4",
+            alt: "higgsboson avatar example",
+          },
+        },
+        {
+          image: {
+            src: "https://avatars.githubusercontent.com/u/539546?v=4",
+            alt: "higgsboson avatar example",
+          },
+        },
+      ],
+    },
+    {
+      titles: {
+        list: "hggs-avatars",
+        item: "hggs-avatars-item",
+        figure: "hggs-avatar",
+        image: "hggs-image",
+      },
+      styles: {
+        header: headerStyles,
+        article: articleStyles,
+        titles: {
+          list: titleStyles,
+          item: titleIndentation1xStyles,
+          figure: titleIndentation2xStyles,
+          image: titleIndentation3xStyles,
+        },
+      },
+      classes: {
+        list: ["hggs-avatars"],
+        item: ["hggs-avatars-item"],
+        figure: ["hggs-avatar"],
+        image: ["hggs-avatar-image"],
+      },
+      attributes: [
+        {
+          image: {
+            src: "https://javierlopezdeancos.dev/src/images/me.png",
+            alt: "higgsboson avatar example",
+          },
+        },
+        {
+          image: {
+            src: "https://avatars.githubusercontent.com/u/951580?v=4",
+            alt: "higgsboson avatar example",
+          },
+        },
+        {
+          image: {
+            src: "https://avatars.githubusercontent.com/u/539546?v=4",
+            alt: "higgsboson avatar example",
+          },
+        },
+      ],
+    },
+    {
+      titles: {
+        list: "hggs-avatars",
+        item: "hggs-avatars-item",
+        figure: "hggs-avatar hggs-avatar--small",
+        image: "hggs-image",
+      },
+      styles: {
+        header: headerStyles,
+        article: articleStyles,
+        titles: {
+          list: titleStyles,
+          item: titleIndentation1xStyles,
+          figure: titleIndentation2xStyles,
+          image: titleIndentation3xStyles,
+        },
+      },
+      classes: {
+        list: ["hggs-avatars"],
+        item: ["hggs-avatars-item"],
+        figure: ["hggs-avatar hggs-avatar--small"],
+        image: ["hggs-avatar-image"],
+      },
+      attributes: [
+        {
+          image: {
+            src: "https://javierlopezdeancos.dev/src/images/me.png",
+            alt: "higgsboson avatar example",
+          },
+        },
+        {
+          image: {
+            src: "https://avatars.githubusercontent.com/u/951580?v=4",
+            alt: "higgsboson avatar example",
+          },
+        },
+        {
+          image: {
+            src: "https://avatars.githubusercontent.com/u/539546?v=4",
+            alt: "higgsboson avatar example",
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/src/theme/index.css
+++ b/src/theme/index.css
@@ -31,6 +31,7 @@
 @import url("../components/field/field.css");
 @import url("../components/links/links.css");
 @import url("../components/avatar/avatar.css");
+@import url("../components/avatars/avatars.css");
 @import url("../components/tag/tag.css");
 @import url("../components/dialog/dialog.css");
 @import url("../components/table/table.css");


### PR DESCRIPTION
# Add `hggs-avatars` component

## Issue
Close #146 

## Description
Add first implementation that represent a list of `hggs-avatar`

## Summary of changes
- [x] Add different files to `hggs-avatars`, `md`, `html`, `css`, `metadata`.
- [x] Import `hggs-avatars` css into higgsboson bundle
- [x] Add `hggs-avatars` into Readme component list reference toc

## Screenshot
![localhost_8000_src_components_avatars_avatars html](https://github.com/javierlopezdeancos/higgsboson/assets/1202463/e0f9a57b-3217-4081-9e33-be5102e11317)
 